### PR TITLE
Omit "total time" rows

### DIFF
--- a/readArbttStats.py
+++ b/readArbttStats.py
@@ -70,7 +70,7 @@ def dailyUsage(dailyfile, minutefile, unmatched):
     next(dailystats)  # Skip headers
     # row = {Day, Tag, Time, Percentage}
     for row in dailystats:
-      if 'omitted' in row[1]:
+      if 'omitted' in row[1] or 'total time' in row[1]:
         continue
       elif 'unmatched' in row[1]:
         tag = unmatched
@@ -107,7 +107,9 @@ def dailyUsage(dailyfile, minutefile, unmatched):
     for row in content:
       day, value = row.split(' ', 1)
       time, inctag, _, _ = value.split(',')
-      if 'unmatched' in inctag:
+      if 'omitted' in inctag or 'total time' in inctag:
+        continue
+      elif 'unmatched' in inctag:
         tag = unmatched
       else:
         tag = inctag.split(':')[1]


### PR DESCRIPTION
Fixes #6 

It seems in my `arbtt-stats` version (arbtt-stats 0.10.2),
there are rows with 'total time' as `inctag` which currently `readArbttStats.py` does not expect.

I'm not sure if there is a better solution, but filtering from inside `readArbttStats.py` for these cases just works.

I'm not sure why the total time is being dumped to the CSV files, as we're not using the `--total-time` option in `arbtt-stats`. I tried running with this to see the difference but the binary then fails.

Another option might be to filter for those entries from within `update`, but I'm not sure about the right syntax in `FILTER`.